### PR TITLE
Add PollingWatchService to Haiku image

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -58,7 +58,7 @@ ifeq ($(call isTargetOs, solaris), false)
       #
 endif
 
-ifeq ($(call isTargetOs, solaris macosx aix), false)
+ifeq ($(call isTargetOs, solaris macosx aix haiku), false)
   java.base_EXCLUDE_FILES += sun/nio/fs/PollingWatchService.java
 endif
 


### PR DESCRIPTION
PollingWatchService is used in Haiku port surces but excluded in make scripts. It's leading to NoClassDefFound exception when try using WatchService.